### PR TITLE
fix: split up actions

### DIFF
--- a/script/deploy/init-deploy/3-setRewardsPermissionPt1.s.sol
+++ b/script/deploy/init-deploy/3-setRewardsPermissionPt1.s.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+import {QueueGrantMintingRights} from "./2-queueGrantMintingRights.s.sol";
+import {HopperEnv} from "script/HopperEnv.sol";
+import {Env} from "eigenlayer-contracts/script/releases/Env.sol";
+import {ZEnvHelpers} from "eigenlayer-contracts/lib/zeus-templates/src/utils/ZEnvHelpers.sol";
+
+contract SetRewardsPermissionPt1 is QueueGrantMintingRights {
+    using HopperEnv for *;
+    using Env for *;
+    using ZEnvHelpers for *;
+
+    function _runAsMultisig() internal virtual override prank(Env.opsMultisig()) {
+        Env.proxy.rewardsCoordinator().setRewardsForAllSubmitter(address(HopperEnv.impl.tokenHopper()), true);
+    }
+
+    function testScript() public virtual override {
+        _runAsEOA();
+        _runAsMultisig();
+
+        // Validate that the token hopper has the permission
+        assertTrue(
+            Env.proxy.rewardsCoordinator().isRewardsForAllSubmitter(address(HopperEnv.impl.tokenHopper())),
+            "token hopper does not have requisite permission on rewardsCoordinator"
+        );
+    }
+}

--- a/script/deploy/init-deploy/4-setRewardsPermissionPt2.s.sol
+++ b/script/deploy/init-deploy/4-setRewardsPermissionPt2.s.sol
@@ -2,25 +2,32 @@
 pragma solidity ^0.8.12;
 
 import {QueueGrantMintingRights} from "./2-queueGrantMintingRights.s.sol";
+import {SetRewardsPermissionPt1} from "./3-setRewardsPermissionPt1.s.sol";
 import {HopperEnv} from "script/HopperEnv.sol";
 import {Env} from "eigenlayer-contracts/script/releases/Env.sol";
 import {ZEnvHelpers} from "eigenlayer-contracts/lib/zeus-templates/src/utils/ZEnvHelpers.sol";
 
-contract SetRewardsPermission is QueueGrantMintingRights {
+contract SetRewardsPermissionPt2 is SetRewardsPermissionPt1 {
     using HopperEnv for *;
     using Env for *;
     using ZEnvHelpers for *;
 
     function _runAsMultisig() internal virtual override prank(Env.opsMultisig()) {
-        Env.proxy.rewardsCoordinator().setRewardsForAllSubmitter(address(HopperEnv.impl.tokenHopper()), true);
         Env.proxy.rewardsCoordinator().setRewardsForAllSubmitter(OLD_TOKEN_HOPPER, false);
     }
 
     function testScript() public virtual override {
         _runAsEOA();
+
+        // Set the rewards permission for the new token hopper
+        SetRewardsPermissionPt1._runAsMultisig();
+        // reset hasPranked so we can use it again
+        _unsafeResetHasPranked();
+
+        // Set the rewards permission for the old token hopper
         _runAsMultisig();
 
-        // Validate that the token hopper has the permission
+        // Validate that the token hopper has the permission (from step 3)
         assertTrue(
             Env.proxy.rewardsCoordinator().isRewardsForAllSubmitter(address(HopperEnv.impl.tokenHopper())),
             "token hopper does not have requisite permission on rewardsCoordinator"

--- a/script/deploy/init-deploy/5-executeGrantMintingRights.s.sol
+++ b/script/deploy/init-deploy/5-executeGrantMintingRights.s.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.12;
 
-import {SetRewardsPermission} from "./3-setRewardsPermission.s.sol";
+import {SetRewardsPermissionPt1} from "./3-setRewardsPermissionPt1.s.sol";
+import {SetRewardsPermissionPt2} from "./4-setRewardsPermissionPt2.s.sol";
 import {QueueGrantMintingRights} from "./2-queueGrantMintingRights.s.sol";
 
 import "eigenlayer-contracts/script/releases/Env.sol";
@@ -15,7 +16,7 @@ import {RewardAllStakersActionGenerator} from "src/RewardAllStakersActionGenerat
 import {IHopperActionGenerator} from "src/interfaces/IHopperActionGenerator.sol";
 import {TimeUtils} from "test/utils/TimeUtils.t.sol";
 
-contract ExecuteUpgradeAndSetTimestampSubmitter is SetRewardsPermission {
+contract ExecuteUpgradeAndSetTimestampSubmitter is SetRewardsPermissionPt2 {
     using HopperEnv for *;
     using Env for *;
     using Encode for *;
@@ -45,8 +46,13 @@ contract ExecuteUpgradeAndSetTimestampSubmitter is SetRewardsPermission {
         // reset hasPranked so we can use it again
         _unsafeResetHasPranked();
 
-        // 3. Set Rewards Permission
-        SetRewardsPermission._runAsMultisig();
+        // 3. Set Rewards PermissionPt1
+        SetRewardsPermissionPt1._runAsMultisig();
+        // reset hasPranked so we can use it again
+        _unsafeResetHasPranked();
+
+        // 4. Set Rewards PermissionPt2
+        SetRewardsPermissionPt2._runAsMultisig();
         // reset hasPranked so we can use it again
         _unsafeResetHasPranked();
 
@@ -102,6 +108,9 @@ contract ExecuteUpgradeAndSetTimestampSubmitter is SetRewardsPermission {
         // Verify timestamps using TimeUtils
         TimeUtils.assertEq(oct9th2025, "Thu Oct 09 2025 00:00:00 GMT+0000");
         TimeUtils.assertEq(oct16th2025, "Thu Oct 16 2025 00:00:00 GMT+0000");
+
+        // Because the earlier tests may warp past the `FIRST_SUBMISSION_START_TIMESTAMP`, we need to warp back to it.
+        vm.warp(FIRST_SUBMISSION_START_TIMESTAMP - 1);
 
         // 0. Validate that we cannot press the button before the first submission start timestamp.
         vm.expectRevert("TokenHopper._canPress: block.timestamp < startTime");

--- a/script/deploy/init-deploy/upgrade.json
+++ b/script/deploy/init-deploy/upgrade.json
@@ -13,11 +13,15 @@
         },
         {
             "type": "multisig",
-            "filename": "3-setRewardsPermission.s.sol"
+            "filename": "3-setRewardsPermissionPt1.s.sol"
         },
         {
             "type": "multisig",
-            "filename": "4-executeGrantMintingRights.s.sol"
+            "filename": "4-setRewardsPermissionPt2.s.sol"
+        },
+        {
+            "type": "multisig",
+            "filename": "5-executeGrantMintingRights.s.sol"
         }
     ]
 }


### PR DESCRIPTION
Because the safe API cannot execute a delegate call (via `multisend`) we need to split up `3-setRewardsPermissions` into two:

1. `3-setRewardsPermissionsPt1`: Sets the reward permission for the new hopper
2. `4-setRewardsPermissionPt2`: Removes the reward permission for the old hopper

In addition, we also update the tests in the last step due to warping too far in time after the protocol council transaction is executable. 